### PR TITLE
Bump: Label Mastermind Version

### DIFF
--- a/.github/config.json
+++ b/.github/config.json
@@ -21,7 +21,7 @@
       "prereleaseName": "alpha",
       "issue": {
         "labels": {
-          "documentation": {
+          "dataSources": {
             "requires": 1,
             "conditions": [
               {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: Videndum/label-mastermind@2.0.1
+      - uses: Videndum/label-mastermind@2.1.0
 
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

Error on line 24 of your config would have caused this config to fail. You should use the same name as specified in the labels. 

So to assign the label "documentation" you would need to use the name "dataSources" on line 24. This is what we have changed